### PR TITLE
Add at() bounds-checked element access (P2821R5)

### DIFF
--- a/include/beman/span/span.hpp
+++ b/include/beman/span/span.hpp
@@ -22,6 +22,7 @@
 #include <iterator>
 #include <limits>
 #include <ranges>
+#include <stdexcept>
 #include <type_traits>
 
 namespace beman::span {
@@ -244,6 +245,14 @@ class span {
     // Pre: idx < size().
     constexpr reference operator[](size_type idx) const noexcept {
         assert(idx < size());
+        return data_[idx];
+    }
+
+    // at(idx): bounds-checked access; throws std::out_of_range if idx >= size() (P2821R5).
+    constexpr reference at(size_type idx) const {
+        if (idx >= size()) {
+            throw std::out_of_range("beman::span::at: index out of range");
+        }
         return data_[idx];
     }
 

--- a/tests/beman/span/span.test.cpp
+++ b/tests/beman/span/span.test.cpp
@@ -201,6 +201,54 @@ TEST(SpanElementAccess, write_through_span) {
     EXPECT_EQ(arr[1], 99);
 }
 
+// at() bounds-checked access (P2821R5, C++26)
+TEST(SpanAt, in_bounds_returns_element) {
+    int arr[] = {10, 20, 30};
+    bsp::span<int> s(arr);
+    EXPECT_EQ(s.at(0), 10);
+    EXPECT_EQ(s.at(1), 20);
+    EXPECT_EQ(s.at(2), 30);
+}
+
+TEST(SpanAt, returns_lvalue_reference_for_mutable_span) {
+    int arr[] = {1, 2, 3};
+    bsp::span<int> s(arr);
+    s.at(1) = 42;
+    EXPECT_EQ(arr[1], 42);
+    static_assert(std::is_same_v<decltype(s.at(0)), int&>);
+}
+
+TEST(SpanAt, throws_out_of_range_at_size_boundary) {
+    int arr[] = {1, 2, 3};
+    bsp::span<int> s(arr);
+    EXPECT_THROW(s.at(3), std::out_of_range);
+}
+
+TEST(SpanAt, throws_out_of_range_well_past_size) {
+    int arr[] = {1, 2, 3};
+    bsp::span<int> s(arr);
+    EXPECT_THROW(s.at(100), std::out_of_range);
+}
+
+TEST(SpanAt, empty_span_always_throws) {
+    bsp::span<int> s;
+    EXPECT_THROW(s.at(0), std::out_of_range);
+}
+
+TEST(SpanAt, fixed_extent_in_bounds_and_out_of_range) {
+    int arr[] = {7, 8, 9, 10};
+    bsp::span<int, 4> s(arr);
+    EXPECT_EQ(s.at(3), 10);
+    EXPECT_THROW(s.at(4), std::out_of_range);
+}
+
+TEST(SpanAt, const_span_returns_reference_to_const) {
+    const int arr[] = {1, 2, 3};
+    bsp::span<const int> s(arr);
+    EXPECT_EQ(s.at(2), 3);
+    static_assert(std::is_same_v<decltype(s.at(0)), const int&>);
+}
+
 // ---------------------------------------------------------------------------
 // Observers
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
Implements the C++26 `at()` member from P2821R5. Same shape as `string::at()` / `vector::at()` / `array::at()` returns a reference on success, throws `std::out_of_range` on out-of-bounds.

```cpp
constexpr reference at(size_type idx) const;
```

Sits next to `operator[]` in `[span.elem]`. Differs from `operator[]` in two ways: not `noexcept`, and the bounds check runs unconditionally rather than as an `assert` that disappears in release builds.

Added seven new tests:

- in-bounds access returns the element
- mutation through the returned reference flows back to the underlying array, and `decltype(s.at(0))` is `int&`
- `at(size())` throws (off-by-one boundary)
- `at(100)` throws on a size-3 span (well past the end)
- empty span throws for any index, including 0
- fixed-extent span: in-bounds returns the element; off-by-one throws
- `span<const int>::at()` returns `const int&`

Local: 52/52 passing.

Fixes #1