### PR TITLE
Apply clang-format and gersemi to pre-existing sources

### DIFF
--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -6,8 +6,5 @@ message("Examples to be built: ${ALL_EXAMPLES}")
 foreach(example ${ALL_EXAMPLES})
     add_executable(beman.span.examples.${example})
     target_sources(beman.span.examples.${example} PRIVATE ${example}.cpp)
-    target_link_libraries(
-        beman.span.examples.${example}
-        PRIVATE beman::span
-    )
+    target_link_libraries(beman.span.examples.${example} PRIVATE beman::span)
 endforeach()

--- a/examples/span_basic_usage.cpp
+++ b/examples/span_basic_usage.cpp
@@ -15,7 +15,8 @@ template <class T, std::size_t E>
 void print_span(beman::span::span<T, E> s) {
     std::cout << "[";
     for (std::size_t i = 0; i < s.size(); ++i) {
-        if (i) std::cout << ", ";
+        if (i)
+            std::cout << ", ";
         std::cout << s[i];
     }
     std::cout << "]  (size=" << s.size() << ")\n";
@@ -34,7 +35,7 @@ int main() {
     // ----------------------------------------------------------------
     // 1. Construct from a C-array (fixed extent deduced)
     // ----------------------------------------------------------------
-    int c_arr[] = {10, 20, 30, 40, 50};
+    int               c_arr[] = {10, 20, 30, 40, 50};
     beman::span::span s1(c_arr); // span<int, 5>
     std::cout << "From C-array:   ";
     print_span(s1);
@@ -73,6 +74,5 @@ int main() {
     // ----------------------------------------------------------------
     // 6. size_bytes
     // ----------------------------------------------------------------
-    std::cout << "size_bytes=" << s3.size_bytes() << " (=" << s3.size()
-              << " * " << sizeof(int) << ")\n";
+    std::cout << "size_bytes=" << s3.size_bytes() << " (=" << s3.size() << " * " << sizeof(int) << ")\n";
 }

--- a/examples/span_bytes.cpp
+++ b/examples/span_bytes.cpp
@@ -24,27 +24,25 @@ int main() {
     // ----------------------------------------------------------------
     // as_bytes: read-only view over the raw bytes of any span
     // ----------------------------------------------------------------
-    int arr[] = {0x01020304, 0x05060708};
+    int            arr[] = {0x01020304, 0x05060708};
     bsp::span<int> s(arr);
 
     auto bytes = bsp::as_bytes(s);
-    std::cout << "as_bytes extent (fixed): " << decltype(bytes)::extent
-              << "  size: " << bytes.size() << "\n";
+    std::cout << "as_bytes extent (fixed): " << decltype(bytes)::extent << "  size: " << bytes.size() << "\n";
 
     std::cout << "Raw bytes of {0x01020304, 0x05060708}: ";
     for (auto b : bytes)
         std::cout << std::hex << static_cast<unsigned>(b) << " ";
     std::cout << std::dec << "\n";
 
-    std::cout << "Checksum: 0x" << std::hex
-              << static_cast<unsigned>(checksum(bytes)) << std::dec << "\n";
+    std::cout << "Checksum: 0x" << std::hex << static_cast<unsigned>(checksum(bytes)) << std::dec << "\n";
 
     // ----------------------------------------------------------------
     // as_writable_bytes: write-only (mutable) view over raw bytes
     // ----------------------------------------------------------------
-    int value = 0;
-    bsp::span<int>     vs(&value, 1);
-    auto               wb = bsp::as_writable_bytes(vs);
+    int            value = 0;
+    bsp::span<int> vs(&value, 1);
+    auto           wb = bsp::as_writable_bytes(vs);
 
     // Write 0xDEADBEEF byte by byte (little-endian on most platforms)
     const std::uint8_t pattern[] = {0xEF, 0xBE, 0xAD, 0xDE};

--- a/examples/span_subviews.cpp
+++ b/examples/span_subviews.cpp
@@ -13,7 +13,8 @@ template <class T, std::size_t E>
 void print(const char* label, bsp::span<T, E> s) {
     std::cout << label << ": [";
     for (std::size_t i = 0; i < s.size(); ++i) {
-        if (i) std::cout << ", ";
+        if (i)
+            std::cout << ", ";
         std::cout << s[i];
     }
     std::cout << "]  extent=";
@@ -47,7 +48,7 @@ int main() {
 
     // Dynamic variants
     bsp::span<int> dyn(arr);
-    auto df = dyn.first(4);
+    auto           df = dyn.first(4);
     print("dyn.first(4) ", df);
 
     auto dl = dyn.last(2);

--- a/include/beman/span/CMakeLists.txt
+++ b/include/beman/span/CMakeLists.txt
@@ -1,6 +1,3 @@
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
-target_sources(
-    beman.span
-    PUBLIC FILE_SET HEADERS FILES span.hpp
-)
+target_sources(beman.span PUBLIC FILE_SET HEADERS FILES span.hpp)

--- a/include/beman/span/span.hpp
+++ b/include/beman/span/span.hpp
@@ -51,9 +51,8 @@ struct is_std_array<std::array<T, N>> : std::true_type {};
 
 // Range element-type compatibility check (per [span.cons])
 template <class Range, class ElementType>
-inline constexpr bool is_compatible_element_type_v = std::is_convertible_v<
-    std::remove_reference_t<std::ranges::range_reference_t<Range>> (*)[],
-    ElementType (*)[]>;
+inline constexpr bool is_compatible_element_type_v =
+    std::is_convertible_v<std::remove_reference_t<std::ranges::range_reference_t<Range>> (*)[], ElementType (*)[]>;
 
 } // namespace detail
 
@@ -62,14 +61,14 @@ template <class ElementType, std::size_t Extent>
 class span {
   public:
     // Member types
-    using element_type     = ElementType;
-    using value_type       = std::remove_cv_t<ElementType>;
-    using size_type        = std::size_t;
-    using difference_type  = std::ptrdiff_t;
-    using pointer          = ElementType*;
-    using const_pointer    = const ElementType*;
-    using reference        = ElementType&;
-    using const_reference  = const ElementType&;
+    using element_type           = ElementType;
+    using value_type             = std::remove_cv_t<ElementType>;
+    using size_type              = std::size_t;
+    using difference_type        = std::ptrdiff_t;
+    using pointer                = ElementType*;
+    using const_pointer          = const ElementType*;
+    using reference              = ElementType&;
+    using const_reference        = const ElementType&;
     using iterator               = pointer;
     using const_iterator         = const_pointer;
     using reverse_iterator       = std::reverse_iterator<iterator>;
@@ -81,13 +80,11 @@ class span {
     // 26.7.3.2 Constructors, copy, and assignment [span.cons]
 
     // Default constructor: only valid when Extent == 0 or Extent == dynamic_extent
-    template <std::size_t E = Extent,
-              std::enable_if_t<E == dynamic_extent || E == 0, int> = 0>
+    template <std::size_t E = Extent, std::enable_if_t<E == dynamic_extent || E == 0, int> = 0>
     constexpr span() noexcept : data_(nullptr), size_(0) {}
 
     // Pointer + count constructor.
-    constexpr explicit(Extent != dynamic_extent) span(pointer ptr, size_type count)
-        : data_(ptr), size_(count) {
+    constexpr explicit(Extent != dynamic_extent) span(pointer ptr, size_type count) : data_(ptr), size_(count) {
         if constexpr (Extent != dynamic_extent) {
             assert(count == Extent);
         }
@@ -102,45 +99,39 @@ class span {
     }
 
     // C array constructor (fixed-size)
-    template <std::size_t N,
-              std::enable_if_t<Extent == dynamic_extent || Extent == N, int> = 0,
-              std::enable_if_t<
-                  std::is_convertible_v<std::remove_pointer_t<decltype(std::data(
-                                            std::declval<ElementType (&)[N]>()))> (*)[],
-                                        ElementType (*)[]>,
-                  int> = 0>
+    template <
+        std::size_t N,
+        std::enable_if_t<Extent == dynamic_extent || Extent == N, int> = 0,
+        std::enable_if_t<
+            std::is_convertible_v<std::remove_pointer_t<decltype(std::data(std::declval<ElementType (&)[N]>()))> (*)[],
+                                  ElementType (*)[]>,
+            int> = 0>
     // NOLINTNEXTLINE(modernize-avoid-c-arrays)
-    constexpr span(ElementType (&arr)[N]) noexcept
-        : data_(arr), size_(N) {}
+    constexpr span(ElementType (&arr)[N]) noexcept : data_(arr), size_(N) {}
 
     // std::array constructor (fixed-size)
     template <class T,
               std::size_t N,
-              std::enable_if_t<Extent == dynamic_extent || Extent == N, int> = 0,
+              std::enable_if_t<Extent == dynamic_extent || Extent == N, int>           = 0,
               std::enable_if_t<std::is_convertible_v<T (*)[], ElementType (*)[]>, int> = 0>
-    constexpr span(std::array<T, N>& arr) noexcept
-        : data_(arr.data()), size_(N) {}
+    constexpr span(std::array<T, N>& arr) noexcept : data_(arr.data()), size_(N) {}
 
     // const std::array constructor
     template <class T,
               std::size_t N,
-              std::enable_if_t<Extent == dynamic_extent || Extent == N, int> = 0,
-              std::enable_if_t<std::is_convertible_v<const T (*)[], ElementType (*)[]>,
-                               int> = 0>
-    constexpr span(const std::array<T, N>& arr) noexcept
-        : data_(arr.data()), size_(N) {}
+              std::enable_if_t<Extent == dynamic_extent || Extent == N, int>                 = 0,
+              std::enable_if_t<std::is_convertible_v<const T (*)[], ElementType (*)[]>, int> = 0>
+    constexpr span(const std::array<T, N>& arr) noexcept : data_(arr.data()), size_(N) {}
 
     // Range constructor (generic contiguous range)
-    template <
-        class Range,
-        std::enable_if_t<!detail::is_span<std::remove_cvref_t<Range>>::value, int> = 0,
-        std::enable_if_t<!detail::is_std_array<std::remove_cvref_t<Range>>::value, int> = 0,
-        std::enable_if_t<!std::is_array_v<std::remove_cvref_t<Range>>, int> = 0,
-        std::enable_if_t<std::ranges::contiguous_range<Range>, int> = 0,
-        std::enable_if_t<std::ranges::sized_range<Range>, int> = 0,
-        std::enable_if_t<std::ranges::borrowed_range<Range> || std::is_const_v<ElementType>,
-                         int> = 0,
-        std::enable_if_t<detail::is_compatible_element_type_v<Range, ElementType>, int> = 0>
+    template <class Range,
+              std::enable_if_t<!detail::is_span<std::remove_cvref_t<Range>>::value, int>                = 0,
+              std::enable_if_t<!detail::is_std_array<std::remove_cvref_t<Range>>::value, int>           = 0,
+              std::enable_if_t<!std::is_array_v<std::remove_cvref_t<Range>>, int>                       = 0,
+              std::enable_if_t<std::ranges::contiguous_range<Range>, int>                               = 0,
+              std::enable_if_t<std::ranges::sized_range<Range>, int>                                    = 0,
+              std::enable_if_t<std::ranges::borrowed_range<Range> || std::is_const_v<ElementType>, int> = 0,
+              std::enable_if_t<detail::is_compatible_element_type_v<Range, ElementType>, int>           = 0>
     constexpr explicit(Extent != dynamic_extent) span(Range&& r)
         : data_(std::ranges::data(r)), size_(std::ranges::size(r)) {
         if constexpr (Extent != dynamic_extent) {
@@ -151,21 +142,18 @@ class span {
     // Cross-span converting constructor.
     template <class OtherElementType,
               std::size_t OtherExtent,
-              std::enable_if_t<
-                  (Extent == dynamic_extent || OtherExtent == dynamic_extent ||
-                   Extent == OtherExtent) &&
-                      std::is_convertible_v<OtherElementType (*)[], ElementType (*)[]>,
-                  int> = 0>
-    constexpr explicit(Extent != dynamic_extent &&
-                       OtherExtent == dynamic_extent) span(const span<OtherElementType,
-                                                                       OtherExtent>& s) noexcept
+              std::enable_if_t<(Extent == dynamic_extent || OtherExtent == dynamic_extent || Extent == OtherExtent) &&
+                                   std::is_convertible_v<OtherElementType (*)[], ElementType (*)[]>,
+                               int> = 0>
+    constexpr explicit(Extent != dynamic_extent && OtherExtent == dynamic_extent)
+        span(const span<OtherElementType, OtherExtent>& s) noexcept
         : data_(s.data()), size_(s.size()) {
         if constexpr (Extent != dynamic_extent) {
             assert(s.size() == Extent);
         }
     }
 
-    constexpr span(const span&) noexcept = default;
+    constexpr span(const span&) noexcept            = default;
     constexpr span& operator=(const span&) noexcept = default;
 
     // 26.7.3.3 Subviews [span.sub]
@@ -173,8 +161,7 @@ class span {
     // first<Count>(): static count.
     template <std::size_t Count>
     constexpr span<ElementType, Count> first() const noexcept {
-        static_assert(Count <= Extent || Extent == dynamic_extent,
-                      "Count out of range for fixed-extent span");
+        static_assert(Count <= Extent || Extent == dynamic_extent, "Count out of range for fixed-extent span");
         assert(Count <= size());
         return span<ElementType, Count>{data_, Count};
     }
@@ -188,8 +175,7 @@ class span {
     // last<Count>(): static count.
     template <std::size_t Count>
     constexpr span<ElementType, Count> last() const noexcept {
-        static_assert(Count <= Extent || Extent == dynamic_extent,
-                      "Count out of range for fixed-extent span");
+        static_assert(Count <= Extent || Extent == dynamic_extent, "Count out of range for fixed-extent span");
         assert(Count <= size());
         return span<ElementType, Count>{data_ + (size() - Count), Count};
     }
@@ -203,27 +189,21 @@ class span {
     // subspan<Offset, Count>(): static offset and count.
     template <std::size_t Offset, std::size_t Count = dynamic_extent>
     constexpr auto subspan() const noexcept {
-        static_assert(Offset <= Extent || Extent == dynamic_extent,
-                      "Offset out of range");
-        static_assert(Count == dynamic_extent || Count <= Extent - Offset ||
-                          Extent == dynamic_extent,
+        static_assert(Offset <= Extent || Extent == dynamic_extent, "Offset out of range");
+        static_assert(Count == dynamic_extent || Count <= Extent - Offset || Extent == dynamic_extent,
                       "Count out of range");
         assert(Offset <= size());
         assert(Count == dynamic_extent || Count <= size() - Offset);
 
         constexpr std::size_t E =
-            (Count != dynamic_extent)
-                ? Count
-                : (Extent != dynamic_extent ? Extent - Offset : dynamic_extent);
+            (Count != dynamic_extent) ? Count : (Extent != dynamic_extent ? Extent - Offset : dynamic_extent);
 
-        return span<ElementType, E>{data_ + Offset,
-                                    Count == dynamic_extent ? size() - Offset : Count};
+        return span<ElementType, E>{data_ + Offset, Count == dynamic_extent ? size() - Offset : Count};
     }
 
     // subspan(offset, count): dynamic.
     constexpr span<ElementType, dynamic_extent> subspan(size_type offset,
-                                                        size_type count = dynamic_extent) const
-        noexcept {
+                                                        size_type count = dynamic_extent) const noexcept {
         assert(offset <= size());
         assert(count == dynamic_extent || count <= size() - offset);
         return {data_ + offset, count == dynamic_extent ? size() - offset : count};
@@ -233,9 +213,7 @@ class span {
 
     [[nodiscard]] constexpr size_type size() const noexcept { return size_; }
 
-    [[nodiscard]] constexpr size_type size_bytes() const noexcept {
-        return size() * sizeof(element_type);
-    }
+    [[nodiscard]] constexpr size_type size_bytes() const noexcept { return size() * sizeof(element_type); }
 
     [[nodiscard]] constexpr bool empty() const noexcept { return size() == 0; }
 
@@ -270,14 +248,10 @@ class span {
     constexpr reverse_iterator rend() const noexcept { return reverse_iterator(begin()); }
 
     // cbegin/cend yield iterators to const elements even when ElementType is non-const
-    constexpr const_iterator cbegin() const noexcept { return data_; }
-    constexpr const_iterator cend() const noexcept { return data_ + size_; }
-    constexpr const_reverse_iterator crbegin() const noexcept {
-        return const_reverse_iterator(cend());
-    }
-    constexpr const_reverse_iterator crend() const noexcept {
-        return const_reverse_iterator(cbegin());
-    }
+    constexpr const_iterator         cbegin() const noexcept { return data_; }
+    constexpr const_iterator         cend() const noexcept { return data_ + size_; }
+    constexpr const_reverse_iterator crbegin() const noexcept { return const_reverse_iterator(cend()); }
+    constexpr const_reverse_iterator crend() const noexcept { return const_reverse_iterator(cbegin()); }
 
   private:
     pointer   data_;
@@ -303,23 +277,17 @@ span(Range&&) -> span<std::remove_reference_t<decltype(*std::data(std::declval<R
 // as_bytes: reinterpret a span as read-only bytes
 template <class ElementType, std::size_t Extent>
 auto as_bytes(span<ElementType, Extent> s) noexcept
-    -> span<const std::byte,
-            Extent == dynamic_extent ? dynamic_extent : sizeof(ElementType) * Extent> {
+    -> span<const std::byte, Extent == dynamic_extent ? dynamic_extent : sizeof(ElementType) * Extent> {
     using return_type =
-        span<const std::byte,
-             Extent == dynamic_extent ? dynamic_extent : sizeof(ElementType) * Extent>;
+        span<const std::byte, Extent == dynamic_extent ? dynamic_extent : sizeof(ElementType) * Extent>;
     return return_type{reinterpret_cast<const std::byte*>(s.data()), s.size_bytes()};
 }
 
 // as_writable_bytes: reinterpret a mutable span as writable bytes
-template <class ElementType,
-          std::size_t Extent,
-          std::enable_if_t<!std::is_const_v<ElementType>, int> = 0>
+template <class ElementType, std::size_t Extent, std::enable_if_t<!std::is_const_v<ElementType>, int> = 0>
 auto as_writable_bytes(span<ElementType, Extent> s) noexcept
-    -> span<std::byte,
-            Extent == dynamic_extent ? dynamic_extent : sizeof(ElementType) * Extent> {
-    using return_type =
-        span<std::byte, Extent == dynamic_extent ? dynamic_extent : sizeof(ElementType) * Extent>;
+    -> span<std::byte, Extent == dynamic_extent ? dynamic_extent : sizeof(ElementType) * Extent> {
+    using return_type = span<std::byte, Extent == dynamic_extent ? dynamic_extent : sizeof(ElementType) * Extent>;
     return return_type{reinterpret_cast<std::byte*>(s.data()), s.size_bytes()};
 }
 

--- a/tests/beman/span/span.test.cpp
+++ b/tests/beman/span/span.test.cpp
@@ -45,7 +45,7 @@ TEST(SpanConstruction, default_static_zero) {
 // ---------------------------------------------------------------------------
 
 TEST(SpanConstruction, pointer_and_count_dynamic) {
-    int arr[] = {1, 2, 3, 4, 5};
+    int            arr[] = {1, 2, 3, 4, 5};
     bsp::span<int> s(arr, 5);
     EXPECT_EQ(s.size(), 5u);
     EXPECT_EQ(s.data(), arr);
@@ -53,7 +53,7 @@ TEST(SpanConstruction, pointer_and_count_dynamic) {
 }
 
 TEST(SpanConstruction, pointer_and_count_static) {
-    int arr[] = {10, 20, 30};
+    int               arr[] = {10, 20, 30};
     bsp::span<int, 3> s(arr, 3);
     EXPECT_EQ(s.size(), 3u);
     EXPECT_EQ(s.data(), arr);
@@ -64,7 +64,7 @@ TEST(SpanConstruction, pointer_and_count_static) {
 // ---------------------------------------------------------------------------
 
 TEST(SpanConstruction, pointer_pair) {
-    int arr[] = {5, 6, 7, 8};
+    int            arr[] = {5, 6, 7, 8};
     bsp::span<int> s(arr, arr + 4);
     EXPECT_EQ(s.size(), 4u);
     EXPECT_EQ(s[0], 5);
@@ -76,20 +76,20 @@ TEST(SpanConstruction, pointer_pair) {
 // ---------------------------------------------------------------------------
 
 TEST(SpanConstruction, c_array_dynamic) {
-    int arr[] = {1, 2, 3};
+    int            arr[] = {1, 2, 3};
     bsp::span<int> s(arr);
     EXPECT_EQ(s.size(), 3u);
     EXPECT_EQ(s.data(), arr);
 }
 
 TEST(SpanConstruction, c_array_static) {
-    int arr[] = {10, 20};
+    int               arr[] = {10, 20};
     bsp::span<int, 2> s(arr);
     EXPECT_EQ(s.size(), 2u);
 }
 
 TEST(SpanConstruction, c_array_deduction) {
-    int arr[] = {1, 2, 3, 4};
+    int       arr[] = {1, 2, 3, 4};
     bsp::span s(arr);
     static_assert(std::is_same_v<decltype(s), bsp::span<int, 4>>);
     EXPECT_EQ(s.size(), 4u);
@@ -101,27 +101,27 @@ TEST(SpanConstruction, c_array_deduction) {
 
 TEST(SpanConstruction, std_array_mutable) {
     std::array<int, 4> arr = {1, 2, 3, 4};
-    bsp::span<int> s(arr);
+    bsp::span<int>     s(arr);
     EXPECT_EQ(s.size(), 4u);
     EXPECT_EQ(s.data(), arr.data());
 }
 
 TEST(SpanConstruction, std_array_const) {
     const std::array<int, 3> arr = {7, 8, 9};
-    bsp::span<const int> s(arr);
+    bsp::span<const int>     s(arr);
     EXPECT_EQ(s.size(), 3u);
     EXPECT_EQ(s[0], 7);
 }
 
 TEST(SpanConstruction, std_array_deduction_mutable) {
     std::array<double, 2> arr = {1.0, 2.0};
-    bsp::span s(arr);
+    bsp::span             s(arr);
     static_assert(std::is_same_v<decltype(s), bsp::span<double, 2>>);
 }
 
 TEST(SpanConstruction, std_array_deduction_const) {
     const std::array<double, 2> arr = {3.0, 4.0};
-    bsp::span s(arr);
+    bsp::span                   s(arr);
     static_assert(std::is_same_v<decltype(s), bsp::span<const double, 2>>);
 }
 
@@ -131,14 +131,14 @@ TEST(SpanConstruction, std_array_deduction_const) {
 
 TEST(SpanConstruction, from_vector) {
     std::vector<int> v = {1, 2, 3, 4, 5};
-    bsp::span<int> s(v);
+    bsp::span<int>   s(v);
     EXPECT_EQ(s.size(), 5u);
     EXPECT_EQ(s.data(), v.data());
 }
 
 TEST(SpanConstruction, from_const_vector) {
     const std::vector<int> v = {10, 20};
-    bsp::span<const int> s(v);
+    bsp::span<const int>   s(v);
     EXPECT_EQ(s.size(), 2u);
     EXPECT_EQ(s[1], 20);
 }
@@ -148,7 +148,7 @@ TEST(SpanConstruction, from_const_vector) {
 // ---------------------------------------------------------------------------
 
 TEST(SpanConstruction, copy_dynamic_from_dynamic) {
-    int arr[] = {1, 2, 3};
+    int            arr[] = {1, 2, 3};
     bsp::span<int> a(arr);
     bsp::span<int> b(a);
     EXPECT_EQ(b.size(), 3u);
@@ -156,17 +156,17 @@ TEST(SpanConstruction, copy_dynamic_from_dynamic) {
 }
 
 TEST(SpanConstruction, const_from_mutable) {
-    int arr[] = {4, 5, 6};
-    bsp::span<int> mutable_s(arr);
+    int                  arr[] = {4, 5, 6};
+    bsp::span<int>       mutable_s(arr);
     bsp::span<const int> const_s(mutable_s);
     EXPECT_EQ(const_s.size(), 3u);
     EXPECT_EQ(const_s[0], 4);
 }
 
 TEST(SpanConstruction, dynamic_from_static) {
-    int arr[] = {1, 2, 3, 4};
+    int               arr[] = {1, 2, 3, 4};
     bsp::span<int, 4> fixed(arr);
-    bsp::span<int> dynamic(fixed);
+    bsp::span<int>    dynamic(fixed);
     EXPECT_EQ(dynamic.size(), 4u);
 }
 
@@ -175,14 +175,14 @@ TEST(SpanConstruction, dynamic_from_static) {
 // ---------------------------------------------------------------------------
 
 TEST(SpanElementAccess, subscript) {
-    int arr[] = {10, 20, 30, 40};
+    int            arr[] = {10, 20, 30, 40};
     bsp::span<int> s(arr);
     EXPECT_EQ(s[0], 10);
     EXPECT_EQ(s[3], 40);
 }
 
 TEST(SpanElementAccess, front_and_back) {
-    int arr[] = {100, 200, 300};
+    int            arr[] = {100, 200, 300};
     bsp::span<int> s(arr);
     EXPECT_EQ(s.front(), 100);
     EXPECT_EQ(s.back(), 300);
@@ -190,12 +190,12 @@ TEST(SpanElementAccess, front_and_back) {
 
 TEST(SpanElementAccess, data_pointer) {
     std::array<int, 3> arr = {1, 2, 3};
-    bsp::span<int> s(arr);
+    bsp::span<int>     s(arr);
     EXPECT_EQ(s.data(), arr.data());
 }
 
 TEST(SpanElementAccess, write_through_span) {
-    int arr[] = {1, 2, 3};
+    int            arr[] = {1, 2, 3};
     bsp::span<int> s(arr);
     s[1] = 99;
     EXPECT_EQ(arr[1], 99);
@@ -206,13 +206,13 @@ TEST(SpanElementAccess, write_through_span) {
 // ---------------------------------------------------------------------------
 
 TEST(SpanObservers, size) {
-    int arr[] = {0, 1, 2, 3, 4};
+    int            arr[] = {0, 1, 2, 3, 4};
     bsp::span<int> s(arr);
     EXPECT_EQ(s.size(), 5u);
 }
 
 TEST(SpanObservers, size_bytes) {
-    int arr[] = {0, 1, 2};
+    int            arr[] = {0, 1, 2};
     bsp::span<int> s(arr);
     EXPECT_EQ(s.size_bytes(), 3 * sizeof(int));
 }
@@ -223,7 +223,7 @@ TEST(SpanObservers, empty_true) {
 }
 
 TEST(SpanObservers, empty_false) {
-    int arr[] = {1};
+    int            arr[] = {1};
     bsp::span<int> s(arr);
     EXPECT_FALSE(s.empty());
 }
@@ -233,18 +233,18 @@ TEST(SpanObservers, empty_false) {
 // ---------------------------------------------------------------------------
 
 TEST(SpanIterators, range_for) {
-    int arr[] = {1, 2, 3, 4, 5};
+    int            arr[] = {1, 2, 3, 4, 5};
     bsp::span<int> s(arr);
-    int sum = 0;
+    int            sum = 0;
     for (int v : s)
         sum += v;
     EXPECT_EQ(sum, 15);
 }
 
 TEST(SpanIterators, begin_end) {
-    int arr[] = {5, 10, 15};
+    int            arr[] = {5, 10, 15};
     bsp::span<int> s(arr);
-    auto it = s.begin();
+    auto           it = s.begin();
     EXPECT_EQ(*it, 5);
     ++it;
     EXPECT_EQ(*it, 10);
@@ -252,8 +252,8 @@ TEST(SpanIterators, begin_end) {
 }
 
 TEST(SpanIterators, reverse_iteration) {
-    int arr[] = {1, 2, 3};
-    bsp::span<int> s(arr);
+    int              arr[] = {1, 2, 3};
+    bsp::span<int>   s(arr);
     std::vector<int> rev(s.rbegin(), s.rend());
     EXPECT_EQ(rev[0], 3);
     EXPECT_EQ(rev[1], 2);
@@ -261,19 +261,18 @@ TEST(SpanIterators, reverse_iteration) {
 }
 
 TEST(SpanIterators, cbegin_cend) {
-    int arr[] = {7, 8, 9};
+    int            arr[] = {7, 8, 9};
     bsp::span<int> s(arr);
     EXPECT_EQ(*s.cbegin(), 7);
     EXPECT_EQ(s.cend() - s.cbegin(), 3);
 
     static_assert(std::is_same_v<decltype(s.cbegin()), bsp::span<int>::const_iterator>);
     static_assert(std::is_same_v<bsp::span<int>::const_iterator, const int*>);
-    static_assert(std::is_same_v<decltype(s.crbegin()),
-                                 bsp::span<int>::const_reverse_iterator>);
+    static_assert(std::is_same_v<decltype(s.crbegin()), bsp::span<int>::const_reverse_iterator>);
 }
 
 TEST(SpanIterators, std_algorithm_sort) {
-    int arr[] = {5, 3, 1, 4, 2};
+    int            arr[] = {5, 3, 1, 4, 2};
     bsp::span<int> s(arr);
     std::sort(s.begin(), s.end());
     EXPECT_EQ(arr[0], 1);
@@ -282,7 +281,7 @@ TEST(SpanIterators, std_algorithm_sort) {
 
 TEST(SpanIterators, std_algorithm_iota) {
     std::array<int, 5> arr{};
-    bsp::span<int> s(arr);
+    bsp::span<int>     s(arr);
     std::iota(s.begin(), s.end(), 1);
     for (int i = 0; i < 5; ++i)
         EXPECT_EQ(arr[i], i + 1);
@@ -293,9 +292,9 @@ TEST(SpanIterators, std_algorithm_iota) {
 // ---------------------------------------------------------------------------
 
 TEST(SpanSubviews, first_static) {
-    int arr[] = {1, 2, 3, 4, 5};
+    int               arr[] = {1, 2, 3, 4, 5};
     bsp::span<int, 5> s(arr);
-    auto f = s.first<3>();
+    auto              f = s.first<3>();
     static_assert(decltype(f)::extent == 3);
     EXPECT_EQ(f.size(), 3u);
     EXPECT_EQ(f[0], 1);
@@ -303,35 +302,35 @@ TEST(SpanSubviews, first_static) {
 }
 
 TEST(SpanSubviews, first_dynamic) {
-    int arr[] = {10, 20, 30, 40};
+    int            arr[] = {10, 20, 30, 40};
     bsp::span<int> s(arr);
-    auto f = s.first(2);
+    auto           f = s.first(2);
     EXPECT_EQ(f.size(), 2u);
     EXPECT_EQ(f[0], 10);
     EXPECT_EQ(f[1], 20);
 }
 
 TEST(SpanSubviews, last_static) {
-    int arr[] = {1, 2, 3, 4, 5};
+    int               arr[] = {1, 2, 3, 4, 5};
     bsp::span<int, 5> s(arr);
-    auto l = s.last<2>();
+    auto              l = s.last<2>();
     static_assert(decltype(l)::extent == 2);
     EXPECT_EQ(l[0], 4);
     EXPECT_EQ(l[1], 5);
 }
 
 TEST(SpanSubviews, last_dynamic) {
-    int arr[] = {10, 20, 30, 40};
+    int            arr[] = {10, 20, 30, 40};
     bsp::span<int> s(arr);
-    auto l = s.last(3);
+    auto           l = s.last(3);
     EXPECT_EQ(l.size(), 3u);
     EXPECT_EQ(l[0], 20);
 }
 
 TEST(SpanSubviews, subspan_static_offset) {
-    int arr[] = {0, 1, 2, 3, 4};
+    int               arr[] = {0, 1, 2, 3, 4};
     bsp::span<int, 5> s(arr);
-    auto sub = s.subspan<2>();
+    auto              sub = s.subspan<2>();
     static_assert(decltype(sub)::extent == 3);
     EXPECT_EQ(sub.size(), 3u);
     EXPECT_EQ(sub[0], 2);
@@ -339,9 +338,9 @@ TEST(SpanSubviews, subspan_static_offset) {
 }
 
 TEST(SpanSubviews, subspan_static_offset_and_count) {
-    int arr[] = {0, 1, 2, 3, 4};
+    int               arr[] = {0, 1, 2, 3, 4};
     bsp::span<int, 5> s(arr);
-    auto sub = s.subspan<1, 3>();
+    auto              sub = s.subspan<1, 3>();
     static_assert(decltype(sub)::extent == 3);
     EXPECT_EQ(sub.size(), 3u);
     EXPECT_EQ(sub[0], 1);
@@ -349,18 +348,18 @@ TEST(SpanSubviews, subspan_static_offset_and_count) {
 }
 
 TEST(SpanSubviews, subspan_dynamic) {
-    int arr[] = {10, 20, 30, 40, 50};
+    int            arr[] = {10, 20, 30, 40, 50};
     bsp::span<int> s(arr);
-    auto sub = s.subspan(1, 3);
+    auto           sub = s.subspan(1, 3);
     EXPECT_EQ(sub.size(), 3u);
     EXPECT_EQ(sub[0], 20);
     EXPECT_EQ(sub[2], 40);
 }
 
 TEST(SpanSubviews, subspan_dynamic_to_end) {
-    int arr[] = {1, 2, 3, 4};
+    int            arr[] = {1, 2, 3, 4};
     bsp::span<int> s(arr);
-    auto sub = s.subspan(2);
+    auto           sub = s.subspan(2);
     EXPECT_EQ(sub.size(), 2u);
     EXPECT_EQ(sub[0], 3);
     EXPECT_EQ(sub[1], 4);
@@ -371,25 +370,25 @@ TEST(SpanSubviews, subspan_dynamic_to_end) {
 // ---------------------------------------------------------------------------
 
 TEST(SpanObjectRepresentation, as_bytes) {
-    int arr[] = {1};
+    int            arr[] = {1};
     bsp::span<int> s(arr);
-    auto bytes = bsp::as_bytes(s);
+    auto           bytes = bsp::as_bytes(s);
     EXPECT_EQ(bytes.size(), sizeof(int));
     static_assert(std::is_same_v<decltype(bytes)::element_type, const std::byte>);
 }
 
 TEST(SpanObjectRepresentation, as_writable_bytes) {
-    int arr[] = {1};
+    int            arr[] = {1};
     bsp::span<int> s(arr);
-    auto bytes = bsp::as_writable_bytes(s);
+    auto           bytes = bsp::as_writable_bytes(s);
     EXPECT_EQ(bytes.size(), sizeof(int));
     static_assert(std::is_same_v<decltype(bytes)::element_type, std::byte>);
 }
 
 TEST(SpanObjectRepresentation, as_bytes_fixed_extent) {
-    int arr[3] = {1, 2, 3};
+    int               arr[3] = {1, 2, 3};
     bsp::span<int, 3> s(arr);
-    auto bytes = bsp::as_bytes(s);
+    auto              bytes = bsp::as_bytes(s);
     static_assert(decltype(bytes)::extent == 3 * sizeof(int));
     EXPECT_EQ(bytes.size(), 3 * sizeof(int));
 }
@@ -416,12 +415,12 @@ TEST(SpanConstexpr, size_and_access) {
 // ---------------------------------------------------------------------------
 
 #if defined(__cpp_lib_span) && __cpp_lib_span >= 202002L
-#include <span>
+    #include <span>
 
 TEST(SpanCompareWithStd, same_size_and_values) {
     std::vector<int> v = {1, 2, 3, 4, 5};
-    std::span<int>  std_s(v);
-    bsp::span<int> beman_s(v);
+    std::span<int>   std_s(v);
+    bsp::span<int>   beman_s(v);
 
     EXPECT_EQ(std_s.size(), beman_s.size());
     for (std::size_t i = 0; i < std_s.size(); ++i) {


### PR DESCRIPTION
The exemplar PR (#12) added a stricter .clang-format and gersemi pre-commit config, but the source files that pre-date the exemplar (examples/, include/beman/span/, tests/beman/span/) were never re-formatted under the new rules. This trips the pre-commit CI on main with "files were modified by this hook". Run both formatters once and commit the result.

<!--
Please take note of the following when contributing:
- Our code of conduct: https://github.com/bemanproject/beman/blob/main/docs/code_of_conduct.md
- The Beman Standard: https://github.com/bemanproject/beman/blob/main/docs/beman_standard.md
-->
