### PR TITLE
Enable beman-tidy v0.5.1 in default mode

### DIFF
--- a/.beman-tidy.yaml
+++ b/.beman-tidy.yaml
@@ -1,0 +1,10 @@
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+# This is the config file for beman-tidy, which checks compliance with the Beman Standard (https://github.com/bemanproject/beman/blob/main/docs/beman_standard.md)
+# Check documentation for beman-tidy here:
+# https://github.com/bemanproject/beman-tidy/blob/main/README.md
+
+disabled_rules:
+    # None
+ignored_paths:
+    - infra/

--- a/.github/workflows/pre-commit-check.yml
+++ b/.github/workflows/pre-commit-check.yml
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 name: Lint Check (pre-commit)
 
 on:

--- a/.markdownlint.yaml
+++ b/.markdownlint.yaml
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 # MD033/no-inline-html : Inline HTML : https://github.com/DavidAnson/markdownlint/blob/v0.35.0/doc/md033.md
 # Disable inline html linter is needed for <details> <summary>
 MD033: false

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 # See https://pre-commit.com for more information
 # See https://pre-commit.com/hooks.html for more hooks
 repos:
@@ -39,10 +40,11 @@ repos:
     hooks:
       - id: codespell
 
-    # Beman Standard checking via beman-tidy
+  # Beman Standard checking via beman-tidy
   - repo: https://github.com/bemanproject/beman-tidy
-    rev: v0.4.1
+    rev: v0.5.1
     hooks:
-    - id: beman-tidy
+      - id: beman-tidy
+        args: [".", "--verbose"]
 
-exclude: 'cookiecutter/|infra/|port/'
+exclude: 'infra/|port/'

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 -->
 
 <!-- markdownlint-disable-next-line line-length -->
-![Library Status](https://raw.githubusercontent.com/bemanproject/beman/refs/heads/main/images/badges/beman_badge-beman_library_under_development.svg) ![Continuous Integration Tests](https://github.com/bemanproject/span/actions/workflows/ci_tests.yml/badge.svg) ![Lint Check (pre-commit)](https://github.com/bemanproject/span/actions/workflows/pre-commit-check.yml/badge.svg) [![Coverage](https://coveralls.io/repos/github/bemanproject/span/badge.svg?branch=main)](https://coveralls.io/github/bemanproject/span?branch=main) ![Standard Target](https://github.com/bemanproject/beman/blob/main/images/badges/cpp29.svg)
+[![Library Status](https://raw.githubusercontent.com/bemanproject/beman/refs/heads/main/images/badges/beman_badge-beman_library_under_development.svg)](https://github.com/bemanproject/beman/blob/main/docs/beman_library_maturity_model.md#the-beman-library-maturity-model) ![Continuous Integration Tests](https://github.com/bemanproject/span/actions/workflows/ci_tests.yml/badge.svg) ![Lint Check (pre-commit)](https://github.com/bemanproject/span/actions/workflows/pre-commit-check.yml/badge.svg) [![Coverage](https://coveralls.io/repos/github/bemanproject/span/badge.svg?branch=main)](https://coveralls.io/github/bemanproject/span?branch=main) ![Standard Target](https://github.com/bemanproject/beman/blob/main/images/badges/cpp29.svg)
 
 `beman.span` is an implementation of various proposed updates to `std::span`.
 


### PR DESCRIPTION
## Summary

- Upgrade beman-tidy pre-commit hook from v0.4.1 to v0.5.1 in default mode
- Add `.beman-tidy.yaml` with `ignored_paths: [infra/]`
- Fix Beman Standard requirement violations for default-mode compliance:
  - Add SPDX license identifiers to config/workflow files
  - Fix library status badge format in README.md

Closes bemanproject/beman-tidy#334 (step 4).

## Test plan

- [x] `pre-commit run --all-files` passes locally
- [ ] CI pre-commit check passes


Made with [Cursor](https://cursor.com)