### PR TITLE
Adopt LWG 4397: reject fixed-extent span from a constant-sized range that doesn't fit

### DIFF
--- a/include/beman/span/span.hpp
+++ b/include/beman/span/span.hpp
@@ -136,6 +136,10 @@ class span {
     constexpr explicit(Extent != dynamic_extent) span(Range&& r)
         : data_(std::ranges::data(r)), size_(std::ranges::size(r)) {
         if constexpr (Extent != dynamic_extent) {
+            if constexpr (requires { std::integral_constant<size_type, std::ranges::size(r)>{}; }) {
+                static_assert(std::ranges::size(r) == Extent,
+                              "span extent does not match the range's constant size (LWG 4397)");
+            }
             assert(std::ranges::size(r) == Extent);
         }
     }

--- a/tests/beman/span/CMakeLists.txt
+++ b/tests/beman/span/CMakeLists.txt
@@ -11,3 +11,72 @@ target_link_libraries(
 
 include(GoogleTest)
 gtest_discover_tests(beman.span.tests.span DISCOVERY_TIMEOUT 60)
+
+# ---------------------------------------------------------------------------
+# LWG 4397 negative-compile test (guarded).
+#
+# The LWG 4397 Mandate rejects e.g. span<int, 42>(views::empty<int>) at compile
+# time, but only on compilers that treat ranges::size(r) on a value-independent
+# range as a constant expression through the constructor parameter (i.e. that
+# implement P2280R4). On other compilers the constructor is well-formed and the
+# extent is only checked at run time, so a negative-compile test would be a
+# false failure there.
+#
+# Probe the current compiler at configure time: the matched-extent construction
+# must compile and the mismatched-extent construction must NOT. Only when both
+# hold do we register the negative-compile test.
+# ---------------------------------------------------------------------------
+
+try_compile(
+    BEMAN_SPAN_LWG4397_MATCH_COMPILES
+    SOURCES ${CMAKE_CURRENT_SOURCE_DIR}/span_lwg4397_match.test.cpp
+    CMAKE_FLAGS "-DINCLUDE_DIRECTORIES=${PROJECT_SOURCE_DIR}/include"
+    CXX_STANDARD 20
+    CXX_STANDARD_REQUIRED TRUE
+)
+
+try_compile(
+    BEMAN_SPAN_LWG4397_MISMATCH_COMPILES
+    SOURCES ${CMAKE_CURRENT_SOURCE_DIR}/span_lwg4397_mismatch.test.cpp
+    CMAKE_FLAGS "-DINCLUDE_DIRECTORIES=${PROJECT_SOURCE_DIR}/include"
+    CXX_STANDARD 20
+    CXX_STANDARD_REQUIRED TRUE
+)
+
+if(
+    BEMAN_SPAN_LWG4397_MATCH_COMPILES
+    AND NOT BEMAN_SPAN_LWG4397_MISMATCH_COMPILES
+)
+    add_executable(
+        beman.span.tests.span_lwg4397_fail
+        EXCLUDE_FROM_ALL
+        span_lwg4397_mismatch.test.cpp
+    )
+    target_link_libraries(
+        beman.span.tests.span_lwg4397_fail
+        PRIVATE beman::span
+    )
+    target_compile_features(
+        beman.span.tests.span_lwg4397_fail
+        PRIVATE cxx_std_20
+    )
+
+    add_test(
+        NAME beman.span.tests.span_lwg4397_mismatch_is_ill_formed
+        COMMAND
+            ${CMAKE_COMMAND} --build ${CMAKE_BINARY_DIR} --target
+            beman.span.tests.span_lwg4397_fail --config $<CONFIG>
+    )
+
+    set_tests_properties(
+        beman.span.tests.span_lwg4397_mismatch_is_ill_formed
+        PROPERTIES WILL_FAIL TRUE
+    )
+    message(STATUS "beman.span: LWG 4397 negative-compile test enabled")
+else()
+    message(
+        STATUS
+        "beman.span: LWG 4397 negative-compile test skipped "
+        "(compiler does not reject the mismatch at compile time)"
+    )
+endif()

--- a/tests/beman/span/span.test.cpp
+++ b/tests/beman/span/span.test.cpp
@@ -8,6 +8,7 @@
 #include <array>
 #include <cstddef>
 #include <numeric>
+#include <ranges>
 #include <type_traits>
 #include <utility>
 #include <vector>
@@ -143,6 +144,19 @@ TEST(SpanConstruction, from_const_vector) {
     bsp::span<const int>   s(v);
     EXPECT_EQ(s.size(), 2u);
     EXPECT_EQ(s[1], 20);
+}
+
+TEST(SpanConstruction, lwg4397_constant_size_matches_extent) {
+    bsp::span<int, 0> s(std::views::empty<int>);
+    EXPECT_EQ(s.size(), 0u);
+    EXPECT_TRUE(s.empty());
+}
+
+TEST(SpanConstruction, lwg4397_runtime_sized_range_not_rejected) {
+    std::vector<int>  v(3);
+    bsp::span<int, 3> s(v);
+    EXPECT_EQ(s.size(), 3u);
+    EXPECT_EQ(s.data(), v.data());
 }
 
 // ---------------------------------------------------------------------------

--- a/tests/beman/span/span_lwg4397_match.test.cpp
+++ b/tests/beman/span/span_lwg4397_match.test.cpp
@@ -1,0 +1,22 @@
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+// Positive compile probe for LWG 4397 (Improve span(R&& r)).
+//
+// Constructing a fixed-extent span from a range whose size is a constant
+// expression that matches the extent is well-formed. Here
+// ranges::size(views::empty<int>) is the constant 0, which equals the extent 0.
+//
+// This file is not built as part of the test suite; it is compiled by
+// try_compile() in the surrounding CMakeLists.txt as the control probe that
+// confirms the toolchain accepts the matching case (paired with
+// span_lwg4397_mismatch.test.cpp, which must be rejected).
+
+#include <beman/span/span.hpp>
+
+#include <ranges>
+
+int main() {
+    beman::span::span<int, 0> s(std::views::empty<int>);
+    (void)s;
+    return 0;
+}

--- a/tests/beman/span/span_lwg4397_mismatch.test.cpp
+++ b/tests/beman/span/span_lwg4397_mismatch.test.cpp
@@ -1,0 +1,23 @@
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+// Negative-compile test for LWG 4397 (Improve span(R&& r)).
+//
+// Constructing a fixed-extent span from a range whose size is a constant
+// expression that does NOT match the extent is a Mandates violation and must be
+// ill-formed. Here ranges::size(views::empty<int>) is the constant 0, which
+// does not equal the extent 42, so this translation unit must fail to compile.
+//
+// This file is compiled by try_compile() in the surrounding CMakeLists.txt as
+// the probe that decides whether the toolchain realizes the Mandate (i.e.
+// implements P2280R4). When it does, this same file is also built as an
+// EXCLUDE_FROM_ALL target and registered as a ctest with the WILL_FAIL property.
+
+#include <beman/span/span.hpp>
+
+#include <ranges>
+
+int main() {
+    beman::span::span<int, 42> s(std::views::empty<int>);
+    (void)s;
+    return 0;
+}


### PR DESCRIPTION
Implements LWG 4397 (Improve `span(R&& r)`), which GCC has already shipped and LWG moved to Ready in Brno. Closes #18.

## What
The range constructor gains the new *Mandate*: when the extent is fixed and `ranges::size(r)` is a constant expression, it must equal the extent. Otherwise, the program is ill-formed. This rejects e.g. `span<int, 42>(views::empty<int>)` at compile time instead of only tripping the runtime precondition. Ranges whose size isn't a constant expression (`std::vector` and friends) are unaffected and still checked at run time via the existing assert (the hardened precondition).

## How
The check sits in the `Extent != dynamic_extent` branch of the constructor, guarded by a `requires` probe that only fires the `static_assert` when `ranges::size(r)` is usable as a constant expression:

```cpp
if constexpr (requires {
                  std::integral_constant<size_type, std::ranges::size(r)>{};
              }) {
    static_assert(std::ranges::size(r) == Extent,
                  "span extent does not match the range's constant size (LWG 4397)");
}
```

Realizing the Mandate requires P2280R4, the size has to be usable as a constant expression *through the constructor parameter*. On compilers without it (e.g. GCC 13) the `requires` is simply never satisfied and the check degrades to the runtime assert, with no false rejections (fixed-extent construction from a `std::vector` still compiles).

## Tests
- Positive unit tests: matched constant extent from `views::empty<int>`, and fixed-extent-from-`vector` staying valid.
- A **guarded** negative-compile test: at configure time CMake `try_compile`s a matching probe (must compile) and a mismatching probe (must not); only when the compiler actually rejects the mismatch is a `WILL_FAIL` ctest wired up around it. On compilers that don't reject it, the test is skipped with a status message.

Verified locally on GCC 13.3 (test correctly skipped, full suite green) and by simulating the reject path (test enabled and passing).